### PR TITLE
Move product description under images

### DIFF
--- a/snipplets/product/product-description.tpl
+++ b/snipplets/product/product-description.tpl
@@ -1,5 +1,5 @@
 {% set description_content = product.description is not empty or settings.show_product_fb_comment_box %}
-<div class="w-md-60 mt-4 mb-2" data-store="product-description-{{ product.id }}">
+<div class="w-md-60 mt-1 mb-2" data-store="product-description-{{ product.id }}">
 
 	{# Product description #}
 

--- a/templates/product.tpl
+++ b/templates/product.tpl
@@ -1,15 +1,15 @@
 <div id="single-product" class="js-product-detail js-product-container js-has-new-shipping js-shipping-calculator-container" data-variants="{{product.variants_object | json_encode }}" data-store="product-detail">
 	<div class="container pt-3 pt-md-4 pb-4">
 		<div class="product-columns mb-md-4">
-			<div class="product-images mb-4 mb-md-0" data-store="product-image-{{ product.id }}">
-				{% include 'snipplets/product/product-image.tpl' %}
-			</div>
+                        <div class="product-images mb-4 mb-md-0" data-store="product-image-{{ product.id }}">
+                                {% include 'snipplets/product/product-image.tpl' %}
+                                {% include 'snipplets/product/product-description.tpl' %}
+                        </div>
 			<div class="product-info" data-store="product-info-{{ product.id }}">
 				{% include 'snipplets/product/product-form.tpl' %}
 			</div>
-		</div>
-		{% include 'snipplets/product/product-description.tpl' %}
-	</div>
+                </div>
+        </div>
 </div>
 
 {# Related products #}


### PR DESCRIPTION
## Summary
- Place product description inside product image container
- Reduce top margin on product description snippet

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9219542c832786d4f11d18761bbc